### PR TITLE
Update to reflect tinystatus .yaml file

### DIFF
--- a/env.go
+++ b/env.go
@@ -49,6 +49,7 @@ func (c *Config) PrintEnv() {
 	fmt.Printf("CHECKS_FILE=%s\n", c.ChecksFile)
 	fmt.Printf("INCIDENTS_FILE=%s\n", c.IncidentsFile)
 	fmt.Printf("STATUS_HISTORY_FILE=%s\n", c.HistoryFile)
+	fmt.Printf("HTML_OUTPUT_DIRECTORY=%s\n", c.HtmlOutputDirectory)
 	fmt.Printf("PORT=%d\n", c.Port)
 	fmt.Printf("TOKEN=%s\n", c.Token)
 	fmt.Printf("CHATID=%s\n", c.Chatid)

--- a/env.go
+++ b/env.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/gomarkdown/markdown"
+	"github.com/joho/godotenv"
+	"github.com/sethvargo/go-envconfig"
+	"gopkg.in/yaml.v3"
+	"log"
+	"os"
+	"path"
+)
+
+type Config struct {
+	CheckInterval       int    `env:"CHECK_INTERVAL, default=60"`
+	MaxHistoryEntries   int    `env:"MAX_HISTORY_ENTRIES, default=10"`
+	ChecksFile          string `env:"CHECKS_FILE, default=checks.yaml"`
+	IncidentsFile       string `env:"INCIDENTS_FILE, default=incidents.html"`
+	HistoryFile         string `env:"HISTORY_FILE, default=history.json"`
+	HtmlOutputDirectory string `env:"HTML_OUTPUT_DIRECTORY, default=status"`
+	Port                int    `env:"PORT"`
+	Token               string `env:"TOKEN"`
+	Chatid              string `env:"CHATID"`
+}
+
+func readEnv() Config {
+	godotenv.Load()
+
+	ctx := context.Background()
+
+	var ret Config
+
+	if err := envconfig.Process(ctx, &ret); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := os.MkdirAll(ret.HtmlOutputDirectory, 0755); err != nil {
+		log.Fatal(err)
+	}
+
+	return ret
+}
+
+func (c *Config) PrintEnv() {
+	fmt.Println("---------------------")
+	fmt.Printf("CHECK_INTERVAL=%d\n", c.CheckInterval)
+	fmt.Printf("MAX_HISTORY_ENTRIES=%d\n", c.MaxHistoryEntries)
+	fmt.Printf("CHECKS_FILE=%s\n", c.ChecksFile)
+	fmt.Printf("INCIDENTS_FILE=%s\n", c.IncidentsFile)
+	fmt.Printf("STATUS_HISTORY_FILE=%s\n", c.HistoryFile)
+	fmt.Printf("PORT=%d\n", c.Port)
+	fmt.Printf("TOKEN=%s\n", c.Token)
+	fmt.Printf("CHATID=%s\n", c.Chatid)
+	fmt.Println("---------------------")
+}
+
+func (c *Config) IndexHtmlFile() string {
+	return path.Join(c.HtmlOutputDirectory, "index.html")
+}
+
+func (c *Config) HistoryHtmlFile() string {
+	return path.Join(c.HtmlOutputDirectory, "history.html")
+}
+
+func (c *Config) ListenHost() string {
+	return fmt.Sprintf(":%d", c.Port)
+}
+
+func (c *Config) ReadIncidentHtml() []byte {
+	incidentMarkdown, err := os.ReadFile(c.IncidentsFile)
+	if err != nil {
+		log.Println("Failed to load incidents:", err)
+		incidentMarkdown = []byte("## All Fine!")
+	}
+	return markdown.ToHTML(incidentMarkdown, nil, nil)
+}
+
+func (c *Config) ReadChecks() []Group {
+	checksData, err := os.ReadFile(c.ChecksFile)
+	if err != nil {
+		log.Fatal("Failed to load checks file:", err)
+	}
+	var groups []Group
+	if err = yaml.Unmarshal(checksData, &groups); err != nil {
+		log.Fatal("Failed to parse checks file:", err)
+	}
+
+	return groups
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,9 @@ module gotinystatus
 go 1.23.0
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require (
+	github.com/gomarkdown/markdown v0.0.0-20241105142532-d03b89096d81 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/sethvargo/go-envconfig v1.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/gomarkdown/markdown v0.0.0-20241105142532-d03b89096d81 h1:5lyLWsV+qCkoYqsKUDuycESh9DEIPVKN6iCFeL7ag50=
+github.com/gomarkdown/markdown v0.0.0-20241105142532-d03b89096d81/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/sethvargo/go-envconfig v1.1.0 h1:cWZiJxeTm7AlCvzGXrEXaSTCNgip5oJepekh/BOQuog=
+github.com/sethvargo/go-envconfig v1.1.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/incidents.html
+++ b/incidents.html
@@ -1,1 +1,0 @@
-<h2>No Incidents Recorded till Now!</h2>

--- a/main.go
+++ b/main.go
@@ -183,15 +183,7 @@ func (c *Config) updateHistory(results []GroupCheckResult) {
 }
 
 func renderTemplate(data map[string]interface{}) string {
-	funcMap := template.FuncMap{
-		"check": func(status bool) string {
-			if status {
-				return "Up"
-			}
-			return "Down"
-		},
-	}
-	tmpl, err := template.New("status").Funcs(funcMap).Parse(templateFile)
+	tmpl, err := template.New("status").Parse(templateFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func main() {
 				http.NotFound(w, r)
 			}
 		})
-		http.HandleFunc("/history", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/history.html", func(w http.ResponseWriter, r *http.Request) {
 			if strings.HasPrefix(r.URL.Path, "/history") {
 				serveFile(w, r, "./"+c.HistoryHtmlFile())
 			} else {

--- a/main.go
+++ b/main.go
@@ -331,8 +331,6 @@ func handleHome(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	runtime.GOMAXPROCS(1) // 1 core is enough
-
 	c := readEnv()
 	log.Println("Monitoring services ...")
 

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func (c *Config) generateHistoryPage() {
 func (c *Config) monitorServices() {
 	for {
 		groups := c.ReadChecks()
-		log.Printf("Groups: %+v", groups)
+		//log.Printf("Groups: %+v", groups)
 		results := runChecks(groups)
 		c.updateHistory(results)
 		data := map[string]interface{}{

--- a/tmpl.go
+++ b/tmpl.go
@@ -85,7 +85,7 @@ const templateFile = `<!DOCTYPE html>
 </div>
 <div class="footer">
     <p>Last updated: {{.last_updated}}</p>
-    <p><a href="history">View Status History</a></p>
+    <p><a href="history.html">View Status History</a></p>
 	<p>Powered by <a href="https://github.com/annihilatorrrr/gotinystatus">GoTinyStatus</a></p>
 </div>
 </body>

--- a/tmpl.go
+++ b/tmpl.go
@@ -1,0 +1,177 @@
+package main
+
+const templateFile = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Go TinyStatus</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            line-height: 1.6;
+            color: #e0e0e0;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #181818;
+            transition: background 0.3s ease, color 0.3s ease;
+        }
+        h1, h2 {
+            color: #e0e0e0;
+            text-align: center;
+        }
+        .status-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 15px;
+            margin-bottom: 40px;
+        }
+        .status-item {
+            background: #242424;
+            border-radius: 8px;
+            padding: 15px;
+            box-shadow: 0 2px 4px rgba(255,255,255,0.1);
+            text-align: center;
+            transition: transform .2s, background 0.3s ease;
+        }
+        .status-item:hover {
+            transform: translateY(-5px);
+        }
+        .status-item h3 {
+            margin: 0 0 10px;
+        }
+        .status-up { color: #27ae60; }
+        .status-down { color: #e74c3c; }
+        .incidents {
+            background: #242424;
+            border-radius: 8px;
+            padding: 20px;
+            box-shadow: 0 2px 4px rgba(255,255,255,0.1);
+            margin-bottom: 40px;
+        }
+        .footer {
+            text-align: center;
+            font-size: .9em;
+            color: #a0a0a0;
+            margin-top: 40px;
+        }
+        .footer a {
+            color: #9b59b6;
+            text-decoration: none;
+        }
+        .footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+<h1>Go TinyStatus</h1>
+<h2>Current Status:</h2>
+{{range .groups}}
+<h3>{{.Title}} Status</h3>
+<div class="status-grid">
+    {{range .CheckResults}}
+    <div class="status-item">
+        <h3>{{.Name}}</h3>
+        <p class="{{if .Status}}status-up{{else}}status-down{{end}}">
+            {{if .Status}}Operational{{else}}Down{{end}}
+        </p>
+    </div>
+    {{end}}
+</div>
+{{end}}
+<h2>Incident History</h2>
+<div class="incidents">
+    {{.incidents}}
+</div>
+<div class="footer">
+    <p>Last updated: {{.last_updated}}</p>
+    <p><a href="history">View Status History</a></p>
+	<p>Powered by <a href="https://github.com/annihilatorrrr/gotinystatus">GoTinyStatus</a></p>
+</div>
+</body>
+</html>`
+
+const historyTemplateFile = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Go TinyStatus History</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            line-height: 1.6;
+            color: #e0e0e0;
+            max-width: 1200px;
+            margin: auto;
+            padding: 20px;
+            background: #181818;
+            transition: background 0.3s ease, color 0.3s ease;
+        }
+        h1, h2 {
+            color: #e0e0e0;
+            text-align: center;
+        }
+        .history-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+            gap: 20px;
+            margin-bottom: 40px;
+        }
+        .history-item {
+            background: #242424;
+            border-radius: 8px;
+            padding: 15px;
+            box-shadow: 0 2px 4px rgba(255,255,255,0.1);
+            max-height: 300px;
+            overflow: auto;
+        }
+        .history-item h2 {
+            font-size: 1.2rem;
+            margin: 0;
+        }
+        .history-entry {
+            margin-bottom: 5px;
+            font-size: 0.9rem;
+            display: flex;
+            justify-content: space-between;
+        }
+        .status-up { color: #27ae60; }
+        .status-down { color: #e74c3c; }
+        .footer {
+            text-align: center;
+            font-size: .9em;
+            color: #a0a0a0;
+            margin-top: 40px;
+        }
+        .footer a {
+            color: #9b59b6;
+            text-decoration: none;
+        }
+        .footer a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+<h1>Go TinyStatus History</h1>
+<div class="history-grid">
+    {{ range $service, $entries := .history }}
+    <div class="history-item">
+        <h2>{{ $service }}</h2>
+        {{ range $entry := $entries }}
+        <div class="history-entry">
+            <span>{{ index (split $entry.Timestamp "T") 0 }} {{ slice (index (split $entry.Timestamp "T") 1) 0 8 }}</span>
+            <span class="{{ if $entry.Status }}status-up{{ else }}status-down{{ end }}">
+                {{ if $entry.Status }}Up{{ else }}Down{{ end }}
+            </span>
+        </div>
+        {{ end }}
+    </div>
+    {{ end }}
+</div>
+<div class="footer">
+    <p>Last updated: {{.last_updated}}</p>
+    <p><a href="/">Back to Current Status</a></p>
+	<p>Powered by <a href="https://github.com/annihilatorrrr/gotinystatus">GoTinyStatus</a></p>
+</div>
+</body>
+</html>`

--- a/tmpl.go
+++ b/tmpl.go
@@ -66,14 +66,14 @@ const templateFile = `<!DOCTYPE html>
 <body>
 <h1>Go TinyStatus</h1>
 <h2>Current Status:</h2>
-{{range .groups}}
-<h3>{{.Title}} Status</h3>
+{{range $group := .groups}}
+<h3>{{$group.Title}} Status</h3>
 <div class="status-grid">
-    {{range .CheckResults}}
+    {{range $result := $group.CheckResults}}
     <div class="status-item">
-        <h3>{{.Name}}</h3>
-        <p class="{{if .Status}}status-up{{else}}status-down{{end}}">
-            {{if .Status}}Operational{{else}}Down{{end}}
+        <h3>{{$result.Name}}</h3>
+        <p class="{{if $result.Status}}status-up{{else}}status-down{{end}}">
+            {{if $result.Status}}Operational{{else}}Down{{end}}
         </p>
     </div>
     {{end}}


### PR DESCRIPTION
The yaml in tinystsatus Python version contains groups etc. Moreover, it is assumed that `.env` file exists. To read it, I added `godotenv`. I fixed groups. I removed `map[string]interface{}` in favor of typed results. Smaller fixes as well (e.g. one should link to `"history.html"` to match the static files, as not everyone serves files using the built-in golang server).